### PR TITLE
ssh终端增加选中直接复制，右键直接黏贴功能，标签上增加右键功能

### DIFF
--- a/i18n/cn.json
+++ b/i18n/cn.json
@@ -72,5 +72,6 @@
   "close all tabs": "关闭所有",
   "close left tabs": "关闭左侧",
   "close right tabs": "关闭右侧",
-  "close other tabs": "关闭其他"
+  "close other tabs": "关闭其他",
+  "send text to all ssh terminals": "发送文本到所有ssh终端"
 }

--- a/i18n/cn.json
+++ b/i18n/cn.json
@@ -66,5 +66,11 @@
   "password": "密码",
   "tab list": "窗口列表",
   "reconnect": "重新连接",
-  "are you sure to reconnect it?(rdp not support)": "确定要重新连接吗? (RDP暂不支持)"
+  "are you sure to reconnect it?(rdp not support)": "确定要重新连接吗? (RDP暂不支持)",
+  "clone connect": "复制窗口",
+  "close current tab": "关闭",
+  "close all tabs": "关闭所有",
+  "close left tabs": "关闭左侧",
+  "close right tabs": "关闭右侧",
+  "close other tabs": "关闭其他"
 }

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -72,5 +72,6 @@
   "close all tabs": "关闭所有",
   "close left tabs": "关闭左侧",
   "close right tabs": "关闭右侧",
-  "close other tabs": "关闭其他"
+  "close other tabs": "关闭其他",
+  "send text to all ssh terminals": "发送文本到所有ssh终端"
 }

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -66,5 +66,11 @@
   "password": "密码",
   "tab list": "窗口列表",
   "reconnect": "重新连接",
-  "are you sure to reconnect it?(rdp not support)": "确定要重新连接吗? (RDP暂不支持)"
+  "are you sure to reconnect it?(rdp not support)": "确定要重新连接吗? (RDP暂不支持)",
+  "clone connect": "复制窗口",
+  "close current tab": "关闭",
+  "close all tabs": "关闭所有",
+  "close left tabs": "关闭左侧",
+  "close right tabs": "关闭右侧",
+  "close other tabs": "关闭其他"
 }

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -72,5 +72,6 @@
   "close all tabs": "关闭所有",
   "close left tabs": "关闭左侧",
   "close right tabs": "关闭右侧",
-  "close other tabs": "关闭其他"
+  "close other tabs": "关闭其他",
+  "send text to all ssh terminals": "发送文本到所有ssh终端"
 }

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -66,5 +66,11 @@
   "password": "密码",
   "tab list": "窗口列表",
   "reconnect": "重新连接",
-  "are you sure to reconnect it?(rdp not support)": "确定要重新连接吗? (RDP暂不支持)"
+  "are you sure to reconnect it?(rdp not support)": "确定要重新连接吗? (RDP暂不支持)",
+  "clone connect": "复制窗口",
+  "close current tab": "关闭",
+  "close all tabs": "关闭所有",
+  "close left tabs": "关闭左侧",
+  "close right tabs": "关闭右侧",
+  "close other tabs": "关闭其他"
 }

--- a/src/app/elements/nav/nav.component.css
+++ b/src/app/elements/nav/nav.component.css
@@ -7,6 +7,7 @@
 .nav ul {
   list-style-type: none;
   line-height: 24px;
+  padding-inline-start: 0;
 }
 
 .nav li {
@@ -57,7 +58,7 @@
 }
 
 .nav .dropdown-content li {
-  float: left;
+  /*float: left;*/
   display: flex;
 }
 

--- a/src/app/elements/nav/nav.component.html
+++ b/src/app/elements/nav/nav.component.html
@@ -3,6 +3,16 @@
   <ul>
     <li><a href="/"><img src="static/imgs/logo.png" height="26px"/></a>
     </li>
+    <li [ngClass]="{'dropdown': true}">
+      <a>{{"Tab List"|trans}}</a>
+      <ul *ngIf="NavList.List.length>1" [ngClass]="{'dropdown-content': true}">
+        <ng-container *ngFor="let t of NavList.List, let idx= index" >
+          <li *ngIf="t.nick!=null" [ngClass]="{'active':idx==NavList.Active,'disconnected':!t.connected, 'hidden': t.closed != false}">
+            <a id="{{ 'tab' + idx }}"   (click)="toTab(idx)">{{t.nick}}</a>
+          </li>
+        </ng-container>
+      </ul>
+    </li>
     <li *ngFor="let v of DataStore.Nav" [ngClass]="{'dropdown': v.children}">
       <a>{{v.name|trans}}</a>
       <ul [ngClass]="{'dropdown-content': v.children}">
@@ -12,15 +22,6 @@
         </li>
       </ul>
     </li>
-    <li [ngClass]="{'dropdown': true}">
-      <a>{{"Tab List"|trans}}</a>
-      <ul *ngIf="NavList.List.length>1" [ngClass]="{'dropdown-content': true}">
-        <ng-container *ngFor="let t of NavList.List, let idx= index" >
-        <li *ngIf="t.nick!=null" [ngClass]="{'active':idx==NavList.Active,'disconnected':!t.connected, 'hidden': t.closed != false}">
-          <a id="{{ 'tab' + idx }}"   (click)="toTab(idx)">{{t.nick}}</a>
-        </li>
-        </ng-container>
-      </ul>
-    </li>
+
   </ul>
 </div>

--- a/src/app/elements/nav/nav.component.ts
+++ b/src/app/elements/nav/nav.component.ts
@@ -122,6 +122,17 @@ export class ElementNavComponent implements OnInit {
         ControlComponent.DisconnectAll();
         break;
       }
+      case'ReconnectAll': {
+        if (!confirm('确定重新连接所有已断开终端? (RDP暂不支持)')) {
+          break;
+        }
+        for (let i = 0; i < NavList.List.length - 1; i++) {
+          if (NavList.List[i].connected !== true && NavList.List[i].type === 'ssh' ) {
+            NavList.List[i].termComp.reconnect();
+          }
+        }
+        break;
+      }
       case 'Website': {
         window.open('http://www.jumpserver.org');
         break;
@@ -249,6 +260,11 @@ export class ElementNavComponent implements OnInit {
           'id': 'Reconnect',
           'click': 'Reconnect',
           'name': 'Reconnect'
+        },
+        {
+          'id': 'ReconnectAll',
+          'click': 'ReconnectAll',
+          'name': 'Reconnect all'
         },
       ]
     }, {

--- a/src/app/elements/ssh-term/ssh-term.component.html
+++ b/src/app/elements/ssh-term/ssh-term.component.html
@@ -1,1 +1,1 @@
-<elements-term (winSizeChangeTrigger)="changeWinSize($event)" [term]="term"></elements-term>
+<elements-term (winSizeChangeTrigger)="changeWinSize($event)"  (contextmenu)="contextMenu($event)" [term]="term"></elements-term>

--- a/src/app/elements/ssh-term/ssh-term.component.ts
+++ b/src/app/elements/ssh-term/ssh-term.component.ts
@@ -4,7 +4,7 @@ import {NavList, View} from '../../pages/control/control/control.component';
 import {UUIDService} from '../../app.service';
 import {CookieService} from 'ngx-cookie-service';
 import {Socket} from '../../utils/socket';
-import {getWsSocket} from '../../globals';
+import {DataStore, getWsSocket} from '../../globals';
 import {TransPipe} from '../../pipes/trans.pipe';
 
 
@@ -27,6 +27,15 @@ export class ElementSshTermComponent implements OnInit, AfterViewInit, OnDestroy
   transPipe: TransPipe;
 
   constructor(private _uuid: UUIDService, private _cookie: CookieService) {
+  }
+
+  contextMenu($event) {
+    this.term.focus();
+    if (DataStore.termSelection !== '') {
+      this.ws.emit('data', {'data': DataStore.termSelection, 'room': NavList.List[this.index].room});
+      $event.preventDefault();
+    }
+
   }
 
   ngOnInit() {
@@ -129,6 +138,14 @@ export class ElementSshTermComponent implements OnInit, AfterViewInit, OnDestroy
         this.view.room = data.room;
         this.view.connected = true;
       }
+    });
+
+    this.term.on('selection', function () {
+      document.execCommand('copy');
+      if (!this.hasSelection) {
+        DataStore.termSelection = '';
+      }
+      DataStore.termSelection = this.getSelection().trim();
     });
   }
 

--- a/src/app/elements/ssh-term/ssh-term.component.ts
+++ b/src/app/elements/ssh-term/ssh-term.component.ts
@@ -31,7 +31,18 @@ export class ElementSshTermComponent implements OnInit, AfterViewInit, OnDestroy
 
   contextMenu($event) {
     this.term.focus();
-    if (DataStore.termSelection !== '') {
+    // ctrl按下则不处理
+    if ($event.ctrlKey) {
+      return;
+    }
+    // @ts-ignore
+    if (navigator.clipboard && navigator.clipboard.readText) {
+      // @ts-ignore
+      navigator.clipboard.readText().then((text) => {
+        this.ws.emit('data', {'data': text, 'room': NavList.List[this.index].room});
+      });
+      $event.preventDefault();
+    } else if (DataStore.termSelection !== '') {
       this.ws.emit('data', {'data': DataStore.termSelection, 'room': NavList.List[this.index].room});
       $event.preventDefault();
     }

--- a/src/app/globals.ts
+++ b/src/app/globals.ts
@@ -101,6 +101,7 @@ export let DataStore: {
   autologin: boolean;
   guacamole_token: string;
   guacamole_token_time: number;
+  termSelection: string;
 } = {
   socket: TermWS,
   Nav: [{}],
@@ -113,7 +114,8 @@ export let DataStore: {
   windowsize: [],
   autologin: false,
   guacamole_token: '',
-  guacamole_token_time: 0
+  guacamole_token_time: 0,
+  termSelection: '',
 };
 export let CSRF = '';
 

--- a/src/app/pages/control/control.component.html
+++ b/src/app/pages/control/control.component.html
@@ -1,5 +1,6 @@
 <div class="container-fluid row" fxLayout="row" ngxSplit="row">
-  <div fxFlex="1 1 20%" minBasis="100px" maxBasis="800px" fxFlexFill ngxSplitArea *ngIf="DataStore.leftbarshow">
+  <div [fxFlex]="DataStore.leftbarshow ? '1 1 20%': '1 1 0'" minBasis="100px" maxBasis="800px" fxFlexFill ngxSplitArea
+       [style.display]="DataStore.leftbarshow ? 'block' : 'none'">
     <pages-control-cleftbar></pages-control-cleftbar>
   </div>
   <div fxFlex="0" ngxSplitHandle [style.display]="activeViewIsRdp() ? 'none' : 'block'" (mouseup)="dragSplitBtn($event)"></div>

--- a/src/app/pages/control/control/control.component.css
+++ b/src/app/pages/control/control/control.component.css
@@ -20,3 +20,20 @@ elements-term, elements-guacamole, elements-settings {
   width: 100%;
   background-color: gray;
 }
+
+
+.batch-command {
+  border-left-width: 0;
+  width: 100%;
+  padding: 0 2px 0 0;
+}
+
+.batch-command > input {
+  height: 26px;
+  padding-left: 14px;
+  width: 100%;
+  line-height: 26px;
+  border: none;
+  background: #2f2a2a;
+  color: #ffffff;
+}

--- a/src/app/pages/control/control/control.component.html
+++ b/src/app/pages/control/control/control.component.html
@@ -2,7 +2,7 @@
   <div fxFlex="0 0 30px" class="search">
     <pages-control-nav></pages-control-nav>
   </div>
-  <div fxFlex="0 0 calc(100%-35px)" id="winContainer">
+  <div fxFlex="0 0 calc(100%-56px)" id="winContainer">
     <div class="window" *ngFor="let m of NavList.List;let i=index"
          [ngClass]="{'active':i==NavList.Active}" style="height: 100%">
       <elements-ssh-term [index]="i"
@@ -22,5 +22,12 @@
                          <!--*ngIf="m.type=='settings'">-->
       <!--</elements-settings>-->
     </div>
+  </div>
+  <div fxflex="0 0 26px" class="batch-command">
+    <input placeholder=" {{'Send text to all ssh terminals'| trans }} ..."
+           maxlength="2048"
+           title="{{'Send text to all ssh terminals'| trans }} ..."
+           (keydown.enter)="sendBatchCommand()"
+           type="text" tabindex="2" spellcheck="false" [(ngModel)]="batchCommand">
   </div>
 </div>

--- a/src/app/pages/control/control/control.component.ts
+++ b/src/app/pages/control/control/control.component.ts
@@ -10,6 +10,7 @@
 import {Component, OnInit} from '@angular/core';
 import {TermWS} from '../../../globals';
 import * as jQuery from 'jquery/dist/jquery.min';
+import {ElementSshTermComponent} from '../../../elements/ssh-term/ssh-term.component';
 
 export class View {
   nick: string;
@@ -24,7 +25,7 @@ export class View {
   room: string;
   Rdp: any;
   Term: any;
-  termComp: any;
+  termComp: ElementSshTermComponent;
 }
 
 export let NavList: {

--- a/src/app/pages/control/control/control.component.ts
+++ b/src/app/pages/control/control/control.component.ts
@@ -43,6 +43,7 @@ export let NavList: {
 })
 export class ControlComponent implements OnInit {
   NavList = NavList;
+  batchCommand: string;
 
   static active(id) {
     NavList.List.forEach((v, k) => {
@@ -57,6 +58,16 @@ export class ControlComponent implements OnInit {
       NavList.List[id].connected = false;
       NavList.List[id].Term.write('\r\n\x1b[31mBye Bye!\x1b[m\r\n');
       TermWS.emit('logout', NavList.List[id].room);
+    }
+  }
+
+  static SendCommandToAllSshTerm(cmd) {
+    for (let i = 0; i < NavList.List.length; i++) {
+      if (NavList.List[i].type !== 'ssh' || NavList.List[i].connected !== true) {
+        continue;
+      }
+      const d = {'data': cmd, 'room': NavList.List[i].room};
+      TermWS.emit('data', d);
     }
   }
 
@@ -76,7 +87,13 @@ export class ControlComponent implements OnInit {
   ngOnInit() {
   }
 
-  // trackByFn(index: number, item: View) {
-  //   return item.id;
-  // }
+  sendBatchCommand() {
+    this.batchCommand = this.batchCommand.trim();
+    if (this.batchCommand === '') {
+      return;
+    }
+    ControlComponent.SendCommandToAllSshTerm(this.batchCommand + '\r');
+    this.batchCommand = '';
+
+  }
 }

--- a/src/app/pages/control/control/controlnav/nav.component.css
+++ b/src/app/pages/control/control/controlnav/nav.component.css
@@ -111,3 +111,92 @@
   background-color: #3a3333;
   color: white
 }
+
+
+
+.basicContext {
+  background: #000;
+  border: none;
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  margin: 0;
+  box-shadow: 0 3px 6px 0px rgba(0,0,0,0.16);
+  position: absolute;
+  opacity: 1;
+  padding: 6px 0;
+  z-index: 1000;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.basicContext, .basicContext * {
+  box-sizing: border-box;
+}
+
+.basicContextContainer {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.basicContext tr {
+  margin: 0;
+}
+
+.basicContext__item {
+  cursor: pointer;
+  padding: 0 6px;
+}
+
+.basicContext td {
+  display: block;
+  padding: 0 35px;
+  text-decoration: none;
+  width: auto;
+  opacity: 1;
+  white-space: nowrap;
+  line-height: 24px;
+  text-shadow: none;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  cursor: pointer;
+}
+.basicContext__item.basicContext__item--separator {
+  background: #181414;
+  border: 0;
+  border-top: none;
+  height: 1px;
+  min-height: 1px;
+  max-height: 1px;
+  padding: 0;
+  border-left: none;
+  text-shadow: 0 0 0 transparent;
+  box-shadow: 0;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  margin: 2px 0;
+}
+tr {
+  display: table-row;
+  vertical-align: inherit;
+  border-color: inherit;
+}
+
+tr:hover {
+  background-color: #463e3e;
+}
+
+.basicContext table {
+  border-spacing: 0 !important;
+}
+
+.basicContext__data {
+  padding: 0 6px;
+}
+

--- a/src/app/pages/control/control/controlnav/nav.component.html
+++ b/src/app/pages/control/control/controlnav/nav.component.html
@@ -6,10 +6,55 @@
   <ul [ngStyle]="{'width':150*NavList.List.length+'px'}">
     <li *ngFor="let m of NavList.List;let i = index"
         [ngClass]="{'active':i==NavList.Active,'disconnected':!m.connected, 'hidden': m.closed != false}"
-        id="termnav-{{i}}" (click)="setActive(i)" (dblclick)="m.edit=true;setActive(i)">
+        id="termnav-{{i}}" (click)="setActive(i)" (dblclick)="m.edit=true;setActive(i)" (contextmenu)="onRightClick($event, i)">
       <span *ngIf="!m.edit" [attr.title]="m.nick">{{m.nick | truncatechars:17 }}</span>
       <input *ngIf="m.edit" [(ngModel)]="m.nick" (blur)="m.edit=false" (keyup.enter)="m.edit=false" autofocus="true"/>
       <a class="close" (click)="close(m,i)">&times;</a>
     </li>
   </ul>
+</div>
+<div #rMenu *ngIf="isShowRMenu" class="basicContext" [style.top]="pos.top" [style.left]="pos.left">
+  <table>
+    <tbody>
+
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rCloneConnect()"><span class="basicContext__icon fa fa-copy"></span> {{ "Clone Connect"|trans }} </td>
+    </tr>
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rReconnect()"><span class="basicContext__icon fa fa-refresh"></span> {{ "Reconnect"|trans }} </td>
+    </tr>
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"   (click)="rClose()"> <span class="basicContext__icon fa fa-close "></span> {{ "Close Current Tab"|trans }} </td>
+    </tr>
+    <ng-template [ngIf]="NavList.List.length>2">
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rCloseAll()"><span class="basicContext__icon fa fa-close"></span> {{ "Close All Tabs"|trans }} </td>
+    </tr>
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rCloseOthers()"><span class="basicContext__icon fa fa-close"></span> {{ "Close Other Tabs"|trans }} </td>
+    </tr>
+    </ng-template>
+    <ng-template [ngIf]="rIdx>0">
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rCloseLeft()"><span class="basicContext__icon fa fa-close"></span> {{ "Close Left Tabs"|trans }} </td>
+    </tr>
+    </ng-template>
+    <ng-template [ngIf]="rIdx!=NavList.List.length-2">
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rCloseRight()"><span class="basicContext__icon fa fa-close"></span> {{ "Close Right Tabs"|trans }} </td>
+    </tr>
+    </ng-template>
+
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rDisconnect()"><span class="basicContext__icon fa fa-pause-circle"></span> {{ "Disconnect"|trans }} </td>
+    </tr>
+    </tbody>
+  </table>
 </div>

--- a/src/app/pages/control/control/controlnav/nav.component.ts
+++ b/src/app/pages/control/control/controlnav/nav.component.ts
@@ -8,7 +8,7 @@
  */
 
 import {Component, ElementRef, OnInit, ViewChild} from '@angular/core';
-import {ControlComponent, NavList} from '../control.component';
+import {ControlComponent, NavList, View} from '../control.component';
 import * as jQuery from 'jquery/dist/jquery.min.js';
 
 @Component({
@@ -19,6 +19,10 @@ import * as jQuery from 'jquery/dist/jquery.min.js';
 export class PagesControlNavComponent implements OnInit {
   setActive = PagesControlNavComponent.setActive;
   NavList = NavList;
+  pos = {left: '100px', top: '100px'};
+  isShowRMenu = false;
+  rIdx = -1;
+
 
   static checkActive(index) {
     const len = NavList.List.length;
@@ -55,6 +59,7 @@ export class PagesControlNavComponent implements OnInit {
   }
 
   ngOnInit() {
+    document.addEventListener('click', this.hideRMenu.bind(this), false);
   }
 
 
@@ -74,6 +79,97 @@ export class PagesControlNavComponent implements OnInit {
 
   scrollright() {
     jQuery('.tabs').scrollLeft(jQuery('.tabs').scrollLeft() + 100);
+  }
+
+  showRMenu(left, top) {
+    this.pos.left = left + 'px';
+    this.pos.top = top + 'px';
+    this.isShowRMenu = true;
+  }
+
+  hideRMenu() {
+    this.isShowRMenu = false;
+  }
+
+  onRightClick(event, tabIdx) {
+    this.showRMenu(event.clientX, event.clientY);
+    this.rIdx = tabIdx;
+    event.preventDefault();
+  }
+
+  rClose() {
+    // 关闭当前tab
+    this.close(NavList.List[this.rIdx].host, this.rIdx);
+  }
+
+  rCloseAll() {
+    // 关闭所有tab
+    while (NavList.List.length > 1) {
+      this.close(NavList.List[0].host, 0);
+    }
+  }
+
+  rCloseOthers() {
+    // 关闭其他tab
+    for (let i = NavList.List.length - 2; i > this.rIdx; i--) {
+      this.close(NavList.List[i].host, i);
+    }
+    while (NavList.List.length > 2) {
+      this.close(NavList.List[0].host, 0);
+    }
+  }
+
+  rCloseRight() {
+    // 关闭右侧tab
+    for (let i = NavList.List.length - 2; i > this.rIdx; i--) {
+      this.close(NavList.List[i].host, i);
+    }
+  }
+
+  rCloseLeft() {
+    // 关闭左侧tab
+    const keepNum = NavList.List.length - this.rIdx;
+    while (NavList.List.length > keepNum) {
+      this.close(NavList.List[0].host, 0);
+    }
+  }
+
+  rCloneConnect() {
+    const v = new View();
+    const id = this.rIdx + 1;
+    const host = NavList.List[this.rIdx].host;
+    const user = NavList.List[this.rIdx].user;
+    v.nick = host.hostname;
+    v.connected = true;
+    v.edit = false;
+    v.closed = false;
+    v.host = host;
+    v.user = user;
+    v.type = NavList.List[this.rIdx].type;
+    NavList.List.splice(id, 0, v);
+    NavList.Active = id;
+  }
+  rReconnect() {
+    NavList.List[this.rIdx].termComp.reconnect();
+  }
+  rDisconnect() {
+    if (!confirm('断开当前连接? (RDP暂不支持)')) {
+      return;
+    }
+    switch (NavList.List[NavList.Active].type) {
+      case 'ssh': {
+        ControlComponent.TerminalDisconnect(NavList.Active);
+        break;
+      }
+      case 'rdp': {
+        ControlComponent.RdpDisconnect(NavList.Active);
+        break;
+      }
+      default: {
+        // statements;
+        break;
+      }
+    }
   }
 
 }


### PR DESCRIPTION
1、在ssh终端窗口中选中文本时直接复制内容到剪贴板，并保存到全局的DataStore对象中，点击右键的时候直接黏贴DataStore中保存的内容，并默认右键事件。如果选中是空文本则清空DataStore中保存的内容，点击右键的时候恢复默认右键事件。

2、标签上增加右键菜单，包括复制窗口，关闭当前窗口，关闭全部窗口，关闭其他窗口，关闭左侧窗口，关闭右侧窗口，断开连接，重新连接。