### PR TITLE
fix jumpserver/jumpserver#3688 guacamole RDP分辨率问题

### DIFF
--- a/src/app/elements/setting/setting.component.ts
+++ b/src/app/elements/setting/setting.component.ts
@@ -10,7 +10,7 @@ import {GlobalSetting, Setting} from '@app/model';
   styles: ['.mat-form-field { width: 100%;}']
 })
 export class ElementSettingComponent implements OnInit {
-  solutionsChoices = ['Auto', '1024x768', '1366x768', '1600x900', '1920×1080'];
+  solutionsChoices = ['Auto', '1024x768', '1366x768', '1600x900', '1920x1080'];
   boolChoices = [{name: 'Yes', value: '1'}, {name: 'No', value: '0'}];
   setting: Setting;
   globalSetting: GlobalSetting;


### PR DESCRIPTION
fix jumpserver/jumpserver#3688 guacamole RDP分辨率问题

1920x1080 分割符错误导致 height 没有传递，应使用字母 `x`