### PR TITLE
增加ssh终端选中复制右键黏贴，增加批量发送ssh命令，增加tab标题右键功能

### DIFF
--- a/src/app/elements/content-tab/content-tab.component.css
+++ b/src/app/elements/content-tab/content-tab.component.css
@@ -12,7 +12,7 @@ li.hidden {
 }
 
 li {
-  display: inline-table;
+  display: inline-block;
   width: 150px;
   height: 30px;
   position: relative;

--- a/src/app/elements/content-tab/content-tab.component.html
+++ b/src/app/elements/content-tab/content-tab.component.html
@@ -3,7 +3,7 @@
   [id]="view.id" (click)="setActive()" (dblclick)="view.editable=true;setActive()"
   [title]="view.host.hostname"
 >
-  <span *ngIf="view.nick && !view.editable">{{view.nick | truncatechars:25 }}</span>
+  <span *ngIf="view.nick && !view.editable" [title]="view.nick">{{view.nick | truncatechars:100 }}</span>
   <input *ngIf="view.editable" [(ngModel)]="view.nick" (blur)="view.editable=false" (keyup.enter)="view.editable=false" autofocus="autofocus"/>
   <a class="close" (click)="close()">&times;</a>
 </li>

--- a/src/app/elements/content/content.component.html
+++ b/src/app/elements/content/content.component.html
@@ -7,8 +7,8 @@
     <div class="tabs" #tabs>
       <ul [ngStyle]="{'width':tabsWidth+'px'}">
         <elements-content-tab
-          *ngFor="let view of viewList"
-          [view]="view" (onAction)="onViewAction($event)">
+          *ngFor="let view of viewList;let i = index"
+          [view]="view" (onAction)="onViewAction($event)" (contextmenu)="onRightClick($event, i)">
         </elements-content-tab>
       </ul>
     </div>
@@ -26,3 +26,49 @@
 </div>
 
 <elements-connect [ngStyle]="{'display': 'none'}" (onNewView)="onNewView($event)" ></elements-connect>
+
+<div #rMenu *ngIf="isShowRMenu" class="basicContext" [style.top]="pos.top" [style.left]="pos.left">
+  <table>
+    <tbody>
+
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rCloneConnect()"><span class="basicContext__icon fa fa-copy"></span> {{ "Clone Connect"|trans }} </td>
+    </tr>
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rReconnect()"><span class="basicContext__icon fa fa-refresh"></span> {{ "Reconnect"|trans }} </td>
+    </tr>
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"   (click)="rClose()"> <span class="basicContext__icon fa fa-close "></span> {{ "Close Current Tab"|trans }} </td>
+    </tr>
+    <ng-template [ngIf]="viewList.length>1">
+      <tr class="basicContext__item basicContext__item--separator"></tr>
+      <tr class="basicContext__item ">
+        <td class="basicContext__data"  (click)="rCloseAll()"><span class="basicContext__icon fa fa-close"></span> {{ "Close All Tabs"|trans }} </td>
+      </tr>
+      <tr class="basicContext__item basicContext__item--separator"></tr>
+      <tr class="basicContext__item ">
+        <td class="basicContext__data"  (click)="rCloseOthers()"><span class="basicContext__icon fa fa-close"></span> {{ "Close Other Tabs"|trans }} </td>
+      </tr>
+    </ng-template>
+    <ng-template [ngIf]="rIdx>0">
+      <tr class="basicContext__item basicContext__item--separator"></tr>
+      <tr class="basicContext__item ">
+        <td class="basicContext__data"  (click)="rCloseLeft()"><span class="basicContext__icon fa fa-close"></span> {{ "Close Left Tabs"|trans }} </td>
+      </tr>
+    </ng-template>
+    <ng-template [ngIf]="rIdx!=viewList.length-1">
+      <tr class="basicContext__item basicContext__item--separator"></tr>
+      <tr class="basicContext__item ">
+        <td class="basicContext__data"  (click)="rCloseRight()"><span class="basicContext__icon fa fa-close"></span> {{ "Close Right Tabs"|trans }} </td>
+      </tr>
+    </ng-template>
+
+    <tr class="basicContext__item basicContext__item--separator"></tr>
+    <tr class="basicContext__item ">
+      <td class="basicContext__data"  (click)="rDisconnect()"><span class="basicContext__icon fa fa-pause-circle"></span> {{ "Disconnect"|trans }} </td>
+    </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/app/elements/content/content.component.html
+++ b/src/app/elements/content/content.component.html
@@ -16,6 +16,13 @@
   <div id="winContainer">
     <elements-content-window *ngFor="let view of viewList" [view]="view" ></elements-content-window>
   </div>
+  <div id="batchCommandDiv">
+    <input placeholder=" {{'Send text to all ssh terminals'| trans }} ..."
+           maxlength="2048"
+           title="{{'Send text to all ssh terminals'| trans }} ..."
+           (keydown.enter)="sendBatchCommand()"
+           type="text" tabindex="2" spellcheck="false" [(ngModel)]="batchCommand">
+  </div>
 </div>
 
 <elements-connect [ngStyle]="{'display': 'none'}" (onNewView)="onNewView($event)" ></elements-connect>

--- a/src/app/elements/content/content.component.scss
+++ b/src/app/elements/content/content.component.scss
@@ -73,6 +73,103 @@
   background: #2f2a2a;
   color: #ffffff;
 }
+
+
+
+.basicContext {
+  background: #000;
+  border: none;
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  margin: 0;
+  box-shadow: 0 3px 6px 0px rgba(0,0,0,0.16);
+  position: absolute;
+  opacity: 1;
+  padding: 6px 0;
+  z-index: 1000;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.basicContext, .basicContext * {
+  box-sizing: border-box;
+}
+
+.basicContextContainer {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.basicContext tr {
+  margin: 0;
+}
+
+.basicContext__item {
+  cursor: pointer;
+  padding: 0 6px;
+}
+
+.basicContext td {
+  display: block;
+  padding: 0 15px;
+  text-decoration: none;
+  min-width: 150px;
+  width: auto;
+  opacity: 1;
+  white-space: nowrap;
+  line-height: 24px;
+  text-shadow: none;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  cursor: pointer;
+  color: rgb(214, 203, 203);
+}
+
+.basicContext__icon {
+  padding-right: 5px;
+}
+
+.basicContext__item.basicContext__item--separator {
+  background: #181414;
+  border: 0;
+  border-top: none;
+  height: 1px;
+  min-height: 1px;
+  max-height: 1px;
+  padding: 0;
+  border-left: none;
+  text-shadow: 0 0 0 transparent;
+  box-shadow: none;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  margin: 2px 0;
+}
+tr {
+  display: table-row;
+  vertical-align: inherit;
+  border-color: inherit;
+}
+
+tr:hover {
+  background-color: #463e3e;
+}
+
+.basicContext table {
+  border-spacing: 0 !important;
+}
+
+.basicContext__data {
+  padding: 0 6px;
+}
+
+
 //
 //.window {
 //  height: 100%;

--- a/src/app/elements/content/content.component.scss
+++ b/src/app/elements/content/content.component.scss
@@ -55,7 +55,23 @@
 }
 
 #winContainer {
-  height: calc(100% - 30px);
+  height: calc(100% - 30px - 26px);
+}
+#batchCommandDiv {
+  height: 26px;
+  border-left-width: 0;
+  width: 100%;
+  padding: 0 2px 0 0;
+}
+
+#batchCommandDiv > input {
+  height: 26px;
+  padding-left: 14px;
+  width: 100%;
+  line-height: 26px;
+  border: none;
+  background: #2f2a2a;
+  color: #ffffff;
 }
 //
 //.window {

--- a/src/app/elements/content/content.component.ts
+++ b/src/app/elements/content/content.component.ts
@@ -10,6 +10,7 @@ import {ViewService} from '@app/services';
 export class ElementContentComponent implements OnInit {
   @ViewChild('tabs') tabsRef: ElementRef;
   viewList: Array<View>;
+  batchCommand: string;
 
   static DisconnectAll() {
   }
@@ -77,6 +78,26 @@ export class ElementContentComponent implements OnInit {
 
   scrollToEnd() {
     this.tabsRef.nativeElement.scrollLeft = this.tabsRef.nativeElement.scrollWidth;
+  }
+
+  sendBatchCommand() {
+    this.batchCommand = this.batchCommand.trim();
+    if (this.batchCommand === '') {
+      return;
+    }
+
+    const cmd = this.batchCommand + '\r';
+    for (let i = 0; i < this.viewList.length; i++) {
+      if (this.viewList[i].type !== 'ssh' || this.viewList[i].connected !== true) {
+        continue;
+      }
+      const d = {'data': cmd, 'room': this.viewList[i].room};
+
+      this.viewList[i].termComp.ws.emit('data', d);
+    }
+
+    this.batchCommand = '';
+
   }
 
 }

--- a/src/app/elements/content/content.component.ts
+++ b/src/app/elements/content/content.component.ts
@@ -11,6 +11,9 @@ export class ElementContentComponent implements OnInit {
   @ViewChild('tabs') tabsRef: ElementRef;
   viewList: Array<View>;
   batchCommand: string;
+  pos = {left: '100px', top: '100px'};
+  isShowRMenu = false;
+  rIdx = -1;
 
   static DisconnectAll() {
   }
@@ -24,6 +27,7 @@ export class ElementContentComponent implements OnInit {
 
   ngOnInit() {
     this.viewList = this.viewSrv.viewList;
+    document.addEventListener('click', this.hideRMenu.bind(this), false);
   }
 
   onNewView(view) {
@@ -98,6 +102,97 @@ export class ElementContentComponent implements OnInit {
 
     this.batchCommand = '';
 
+  }
+
+  showRMenu(left, top) {
+    this.pos.left = left + 'px';
+    this.pos.top = top + 'px';
+    this.isShowRMenu = true;
+  }
+
+  hideRMenu() {
+    this.isShowRMenu = false;
+  }
+
+  onRightClick(event, tabIdx) {
+    this.showRMenu(event.clientX, event.clientY);
+    this.rIdx = tabIdx;
+    event.preventDefault();
+  }
+
+  rClose() {
+    // 关闭当前tab
+    this.closeView(this.viewList[this.rIdx]);
+  }
+
+  rCloseAll() {
+    // 关闭所有tab
+    while (this.viewList.length > 0) {
+      this.closeView(this.viewList[0]);
+    }
+  }
+
+  rCloseOthers() {
+    // 关闭其他tab
+    for (let i = this.viewList.length - 1; i > this.rIdx; i--) {
+      this.closeView(this.viewList[i]);
+    }
+    while (this.viewList.length > 1) {
+      this.closeView(this.viewList[0]);
+    }
+  }
+
+  rCloseRight() {
+    // 关闭右侧tab
+    for (let i = this.viewList.length - 1; i > this.rIdx; i--) {
+      this.closeView(this.viewList[i].host);
+    }
+  }
+
+  rCloseLeft() {
+    // 关闭左侧tab
+    const keepNum = this.viewList.length - this.rIdx;
+    while (this.viewList.length > keepNum) {
+      this.closeView(this.viewList[0]);
+    }
+  }
+
+  rCloneConnect() {
+    const v = new View();
+    const id = this.rIdx + 1;
+    const host = this.viewList[this.rIdx].host;
+    const user = this.viewList[this.rIdx].user;
+    v.nick = host.hostname;
+    v.connected = true;
+    v.editable = false;
+    v.closed = false;
+    v.host = host;
+    v.user = user;
+    v.type = this.viewList[this.rIdx].type;
+    this.viewList.splice(id, 0, v);
+    this.setViewActive(v);
+  }
+  rReconnect() {
+    this.viewList[this.rIdx].termComp.reconnect();
+  }
+  rDisconnect() {
+    if (!confirm('断开当前连接? (RDP暂不支持)')) {
+      return;
+    }
+    switch (this.viewList[this.rIdx].type) {
+      case 'ssh': {
+        this.viewList[this.rIdx].termComp.logout();
+        break;
+      }
+      case 'rdp': {
+        // statements
+        break;
+      }
+      default: {
+        // statements;
+        break;
+      }
+    }
   }
 
 }

--- a/src/app/elements/nav/nav.component.css
+++ b/src/app/elements/nav/nav.component.css
@@ -13,6 +13,7 @@
   box-sizing: border-box;
   font-weight: 400;
   text-align: left;
+  padding-inline-start: 15px;
 }
 
 .nav li {

--- a/src/app/elements/nav/nav.component.css
+++ b/src/app/elements/nav/nav.component.css
@@ -13,6 +13,8 @@
   box-sizing: border-box;
   font-weight: 400;
   text-align: left;
+}
+.nav ul.nav-main {
   padding-inline-start: 15px;
 }
 

--- a/src/app/elements/nav/nav.component.html
+++ b/src/app/elements/nav/nav.component.html
@@ -3,6 +3,18 @@
     <li style="padding-right: 10px">
       <a href="/"><img src="static/imgs/logo.png" height="26px"/></a>
     </li>
+    <li [ngClass]="{'dropdown': true}">
+      <a>{{"Tab List"|trans}}</a>
+      <ul *ngIf="viewList.length > 0" [ngClass]="{'dropdown-content': true}">
+        <ng-container *ngFor="let v of viewList, let idx = index" >
+          <li *ngIf="v.nick!=null" [ngClass]="{'disconnected':!v.connected, 'hidden': v.closed != false}">
+          <span [class.active]="v.active">
+            <a id="{{ 'tab' + idx }}"  (click)="_viewSrv.activeView(v)"><i class="fa fa-circle flag"></i> {{v.nick}} </a>
+          </span>
+          </li>
+        </ng-container>
+      </ul>
+    </li>
     <li *ngFor="let v of navs" [ngClass]="{'dropdown': v.children}" >
       <a>{{v.name|trans}}</a>
       <ul [ngClass]="{'dropdown-content': v.children}" *ngIf="v.children">
@@ -12,17 +24,6 @@
         </li>
       </ul>
     </li>
-    <li [ngClass]="{'dropdown': true}">
-      <a>{{"Tab List"|trans}}</a>
-      <ul *ngIf="viewList.length > 0" [ngClass]="{'dropdown-content': true}">
-        <ng-container *ngFor="let v of viewList, let idx = index" >
-        <li *ngIf="v.nick!=null" [ngClass]="{'disconnected':!v.connected, 'hidden': v.closed != false}">
-          <span [class.active]="v.active">
-            <a id="{{ 'tab' + idx }}"  (click)="_viewSrv.activeView(v)"><i class="fa fa-circle flag"></i> {{v.nick}} </a>
-          </span>
-        </li>
-        </ng-container>
-      </ul>
-    </li>
+
   </ul>
 </div>

--- a/src/app/elements/nav/nav.component.ts
+++ b/src/app/elements/nav/nav.component.ts
@@ -273,18 +273,19 @@ export class ElementNavComponent implements OnInit {
   Language(lan: string) {
     this._cookie.set('lang', lan, 30);
     this._http.get('/luna/i18n/' + lan + '.json').subscribe(
-      data => {
-        this._localStorage.set('lang', JSON.stringify(data));
+      respData => {
+        this._localStorage.set('lang', JSON.stringify(respData));
+        const l = this._localStorage.get('lang');
+        if (l) {
+          const data = JSON.parse(l);
+          Object.keys(data).forEach((k, _) => {
+            i18n.set(k, data[k]);
+          });
+        }
+        location.reload();
       }
     );
-    const l = this._localStorage.get('lang');
-    if (l) {
-      const data = JSON.parse(l);
-      Object.keys(data).forEach((k, _) => {
-        i18n.set(k, data[k]);
-      });
-    }
-    location.reload();
+
   }
 
   Setting() {

--- a/src/app/elements/ssh-term/ssh-term.component.html
+++ b/src/app/elements/ssh-term/ssh-term.component.html
@@ -1,1 +1,1 @@
-<elements-term (winSizeChangeTrigger)="changeWinSize($event)" [term]="term"></elements-term>
+<elements-term (winSizeChangeTrigger)="changeWinSize($event)"  (contextmenu)="contextMenu($event)" [term]="term"></elements-term>

--- a/src/app/elements/ssh-term/ssh-term.component.ts
+++ b/src/app/elements/ssh-term/ssh-term.component.ts
@@ -56,6 +56,7 @@ export class ElementSshTermComponent implements OnInit, OnDestroy {
       this.connectHost();
     });
     // this.view.type = 'ssh';
+    this.view.termComp = this;
   }
 
   newTerm() {

--- a/src/app/elements/ssh-term/ssh-term.component.ts
+++ b/src/app/elements/ssh-term/ssh-term.component.ts
@@ -81,7 +81,7 @@ export class ElementSshTermComponent implements OnInit, OnDestroy {
   }
 
   reconnect() {
-    if (this.view.connected !== true) {
+    if (this.view.connected === true) {
       if (!confirm(translate('Are you sure to reconnect it?(RDP not support)'))) {
         return;
       }
@@ -177,6 +177,9 @@ export class ElementSshTermComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this._logger.debug('Close view');
+    this.logout();
+  }
+  logout(): void {
     if (this.view && (this.view.room === this.roomID)) {
       this.view.connected = false;
       this.ws.emit('logout', this.roomID);

--- a/src/app/globals.ts
+++ b/src/app/globals.ts
@@ -28,7 +28,8 @@ export const DataStore: _DataStore = {
   windowSize: [],
   autoLogin: false,
   guacamoleToken: '',
-  guacamoleTokenTime: 0
+  guacamoleTokenTime: 0,
+  termSelection: ''
 };
 
 export let Browser = new _Browser();

--- a/src/app/model.ts
+++ b/src/app/model.ts
@@ -1,3 +1,4 @@
+import {ElementSshTermComponent} from '@app/elements/ssh-term/ssh-term.component';
 
 export class UserGroup {
   id: string;
@@ -119,6 +120,7 @@ export class View {
   token: any;
   DatabaseApp: string;
   shareroomId: string;
+  termComp: ElementSshTermComponent;
 }
 
 export class ViewAction {

--- a/src/app/model.ts
+++ b/src/app/model.ts
@@ -144,7 +144,7 @@ export class DataStore {
   autoLogin: boolean;
   guacamoleToken: string;
   guacamoleTokenTime: number;
-
+  termSelection: string;
 }
 
 export class Browser {

--- a/src/app/utils/socket.ts
+++ b/src/app/utils/socket.ts
@@ -79,5 +79,8 @@ export class Socket {
   on(type: string, fn: Function, opt_scope?: any, opt_oneshot?: boolean) {
     this.emitter.on(type, fn, opt_scope, opt_oneshot);
   }
+  off(type: string, fn: Function) {
+    this.emitter.off(type, fn);
+  }
 }
 

--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -84,5 +84,6 @@
   "Asset": "资产",
   "start time":"开始时间",
   "download":"下载录像",
-  "idle timeout, connection has been disconnected": "空闲超时，链接已断开"
+  "idle timeout, connection has been disconnected": "空闲超时，链接已断开",
+  "send text to all ssh terminals": "发送文本到所有ssh终端"
 }

--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -85,5 +85,13 @@
   "start time":"开始时间",
   "download":"下载录像",
   "idle timeout, connection has been disconnected": "空闲超时，链接已断开",
-  "send text to all ssh terminals": "发送文本到所有ssh终端"
+  "send text to all ssh terminals": "发送文本到所有ssh终端",
+  "reconnect": "重新连接",
+  "are you sure to reconnect it?(rdp not support)": "确定要重新连接吗? (RDP暂不支持)",
+  "clone connect": "复制窗口",
+  "close current tab": "关闭",
+  "close all tabs": "关闭所有",
+  "close left tabs": "关闭左侧",
+  "close right tabs": "关闭右侧",
+  "close other tabs": "关闭其他"
 }


### PR DESCRIPTION
1、ssh终端窗口增加选中复制，右键黏贴功能。
2、底部增加一个文本框用来发送命令到所有ssh终端，窗口列表菜单调整到第一位，下拉的时候防止遮挡ssh终端的内容。
3、增加标签上的右键菜单（关闭，复制，重新连接等功能），修正切换中文文件名错误问题
4、ElementSshTermComponent的ngOnDestroy中增加对ws的监听事件注销和对term的destory方法调用，防止内存泄漏
5、padding-inline-start限定菜单栏第一个图标，防止影响其他下拉菜单。菜单栏的第一个图片默认padding-inline-start默认为40px，改为15px，减少一点空隙