### PR TITLE
设置对话框中增加可以设置是否开启右键快速复制功能，默认是不开启右键快速复制功能

### DIFF
--- a/src/app/elements/nav/nav.component.ts
+++ b/src/app/elements/nav/nav.component.ts
@@ -243,7 +243,7 @@ export class ElementNavComponent implements OnInit {
     const dialog = this._dialog.open(
       ElementSettingComponent,
       {
-        height: '370px',
+        height: '410px',
         width: '400px',
       });
     dialog.afterClosed().subscribe(result => {

--- a/src/app/elements/setting/setting.component.html
+++ b/src/app/elements/setting/setting.component.html
@@ -25,6 +25,13 @@
   </mat-select>
 </mat-form-field>
 
+<mat-form-field>
+  <mat-select [(value)]="setting.quickPaste"
+              placeholder="{{'Right mouse quick paste'| translate }}" >
+    <mat-option *ngFor="let s of boolChoices"  value="{{s.value}}">{{s.name| translate}}</mat-option>
+  </mat-select>
+</mat-form-field>
+
 <div style="float: right" [style.padding-top]="globalSetting.WINDOWS_SKIP_ALL_MANUAL_PASSWORD ? '20px' : '0'">
   <button mat-raised-button (click)="onNoClick()">{{"Cancel"| translate}}</button>
   <button mat-raised-button color="primary" (click)="onSubmit()">{{"Confirm"| translate}}</button>

--- a/src/app/elements/ssh-term/ssh-term.component.ts
+++ b/src/app/elements/ssh-term/ssh-term.component.ts
@@ -40,7 +40,7 @@ export class ElementSshTermComponent implements OnInit, OnDestroy {
   contextMenu($event) {
     this.term.focus();
     // ctrl按下则不处理
-    if ($event.ctrlKey) {
+    if ($event.ctrlKey || this.settingSvc.setting.quickPaste !== '1') {
       return;
     }
     // @ts-ignore

--- a/src/app/model.ts
+++ b/src/app/model.ts
@@ -203,6 +203,7 @@ export class Setting {
   fontSize: number = 14;
   isLoadTreeAsync: string = '1';
   isSkipAllManualPassword: string = '0';
+  quickPaste = '0';
 }
 
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -50,5 +50,6 @@
 	"success": "success",
 	"system user": "system user",
 	"user": "user",
-  "Open in new window": "Open in new window"
+	"Open in new window": "Open in new window",
+	"Right mouse quick paste": "Right mouse quick paste"
 }

--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -50,5 +50,6 @@
 	"success": "成功",
 	"system user": "系统用户",
 	"user": "用户",
-  "Open in new window": "新窗口打开"
+	"Open in new window": "新窗口打开",
+  "Right mouse quick paste": "右键快速粘贴"
 }


### PR DESCRIPTION
设置对话框中增加可以设置是否开启右键快速复制功能，默认是不开启右键快速复制功能。增加这个配置选项，防止部分用户不习惯右键快速粘贴导致误操作。