### PR TITLE
ssh终端重新连接的时候不刷新整个iframe页面

### DIFF
--- a/src/app/elements/iframe/iframe.component.ts
+++ b/src/app/elements/iframe/iframe.component.ts
@@ -45,6 +45,9 @@ export class ElementIframeComponent implements OnInit, AfterViewInit, OnDestroy 
         case 'CLOSE':
           this.view.connected = false;
           break;
+        case 'CONNECTED':
+          this.view.connected = true;
+          break;
         case 'CLICK':
           document.body.click();
           break;
@@ -86,6 +89,12 @@ export class ElementIframeComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   reconnect() {
+    // @ts-ignore
+    if (typeof (this.iframeWindow.Reconnect) === 'function') {
+      // @ts-ignore
+      this.iframeWindow.Reconnect();
+      return;
+    }
     const url = this.src;
     this.src = 'about:blank';
     setTimeout(() => {


### PR DESCRIPTION
增加判断iframe内容是否提供Reconnect方法，有提供的话，直接调用Reconnect，而不是刷新整个页面。由于安全等保需要ssh连接会话超时时间设置较短，ssh终端进程超时后自动断开，重新连接的时候想看到之前屏幕输入的内容，因此增加了这个功能