### PR TITLE
perf: avoid triggering unnecessary requests when speed down asciinema player

### DIFF
--- a/src/app/elements/replay/asciicast/asciicast.component.ts
+++ b/src/app/elements/replay/asciicast/asciicast.component.ts
@@ -65,10 +65,10 @@ export class ElementReplayAsciicastComponent implements OnInit {
   }
 
   speedDown() {
-    this.speed--;
-    if (this.speed <= 0) {
-      this.speed = 1;
+    if (this.speed <= 1) {
+      return
     }
+    this.speed--;
     this.currentTime = this.player.getCurrentTime();
     this.resetPlayer();
     this.player.setCurrentTime(this.currentTime);


### PR DESCRIPTION
It seems there's no need to trigger `speedDown` when the speed is already at 1, which could help avoid unnecessary requests.