### PR TITLE
fix: error对象缺失导致无法渲染对话框

### DIFF
--- a/src/app/services/connect-token/index.ts
+++ b/src/app/services/connect-token/index.ts
@@ -43,7 +43,7 @@ export class ConnectTokenService {
           resolve(token);
         },
         (error) => {
-          this.handleError({tokenID: connectToken.id, code: error.error.code, tokenAction: 'exchange'}, resolve);
+          this.handleError({tokenID: connectToken.id, code: error.error.code, tokenAction: 'exchange', error: error}, resolve);
         }
       );
     });


### PR DESCRIPTION
exchange 接口返回 {"error": "Internal Server Error"} 时会导致 dialog 无法正常渲染