### PR TITLE
fix: get correct current time on ascii player

### DIFF
--- a/src/app/elements/replay/asciicast/asciicast.component.ts
+++ b/src/app/elements/replay/asciicast/asciicast.component.ts
@@ -170,10 +170,10 @@ export class ElementReplayAsciicastComponent implements OnInit, AfterViewInit {
   /**
    * 重置播放器并保持当前播放位置和状态
    */
-  private resetPlayerWithCurrentTime() {
+  private async resetPlayerWithCurrentTime() {
     if (!this.player) return;
 
-    this.currentTime = this.player.getCurrentTime();
+    this.currentTime = await this.player.getCurrentTime();
 
     if (isNaN(this.currentTime) || this.currentTime < 0) {
       this.currentTime = 0;


### PR DESCRIPTION
The `getCurrentTime()` function now returns a promise since [asciinema-player v3.9.0-rc.1](https://github.com/asciinema/asciinema-player/commit/d142aec74245d95b8c032e30bc944844fb2329d1#diff-046e8bf4985eb48c175bf13466254e97e15205e6b41c96f8c550bc133ce29821).
